### PR TITLE
Fix dependency error.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 dependencies:
   flutter:
     sdk: flutter
-  intl: 0.15.2
+  intl: 0.15.7
   
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Bump version of intl package to 0.15.7 which allows 'flutter packages get' to complete. Previous versions of intl did not support sdk 2+, current Dart SDK version is 2.1.0-dev.3.1.